### PR TITLE
adding perl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /root
 # Service Build Dependencies
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache alpine-sdk libffi-dev build-base musl-dev libsodium-dev jq wget unzip && \
+    apk add --no-cache alpine-sdk libffi-dev build-base musl-dev libsodium-dev jq wget unzip perl && \
     apk add --no-cache openssl-dev ca-certificates && \
     apk add --no-cache git zsh bash go && \
     apk add --no-cache python py-pip python-dev py-setuptools && \


### PR DESCRIPTION
I need perl for some of the scripting I am doing that leverages this docker image.  Building the image locally, the image size went from `1.06GB`  to `1.09GB` after adding perl.